### PR TITLE
Slight modifiction of esgf-pub_env yaml

### DIFF
--- a/esgf-pub_env.yml
+++ b/esgf-pub_env.yml
@@ -71,7 +71,7 @@ dependencies:
   - zlib=1.2.11
   - pip:
     - cdf2cim==0.3.2.0
-    - cf-python==2.3.2
+    - cf-python==2.3.3
     - cftime==1.0.3.4
     - decorator==4.3.2
     - esgcet==3.5.11

--- a/esgf-pub_env.yml
+++ b/esgf-pub_env.yml
@@ -91,7 +91,6 @@ dependencies:
     - nose==1.3.7
     - pbr==5.1.2
     - pika==0.11.2
-    - psutil==5.5.0
     - psycopg2==2.7.7
     - regrid2==3.0.0
     - requests-cache==0.4.13

--- a/esgf-pub_env.yml
+++ b/esgf-pub_env.yml
@@ -2,6 +2,7 @@ name: esgf-pub
 channels:
   - conda-forge
   - defaults
+  - anaconda
 dependencies:
   - asn1crypto=0.24.0
   - blas=1.1
@@ -54,6 +55,7 @@ dependencies:
   - openssl=1.0.2p
   - ossuuid=1.6.2
   - pip=19.0.1
+  - psutil=5.5.0
   - pycparser=2.19
   - pyopenssl=18.0.0
   - pysocks=1.6.8


### PR DESCRIPTION
Those modifications are required to run "conda env create -f esgf-pub_env.yml" through the esgf-docker. No need to have gcc/make installed to run the yml which was needed before for "cf-python" and "psutil" packages. 
The yaml can be now used for all kind of ESGF installation (bash, docker, ansible).